### PR TITLE
[PR] Adjust body class names on style guide pages

### DIFF
--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -124,7 +124,7 @@
 	</noscript>
 </head>
 
-<body class="home page page-id-2 page-template page-template-template-builder page-template-template-builder-php domain-hub-wsu-edu path-jeremy opensansy single five5 ten8 twenty15 depth-0 section- page-">
+<body class="home page page-template page-template-template-builder page-template-template-builder-php opensansy single depth-0">
 
 
 <div id="jacket" class="style-bookmark colors-blue spacing-loose">

--- a/style-guide/general-elements.html
+++ b/style-guide/general-elements.html
@@ -124,7 +124,7 @@
 	</noscript>
 </head>
 
-<body class="home page page-id-2 page-template page-template-template-builder page-template-template-builder-php domain-hub-wsu-edu path-jeremy opensansy single five5 ten8 twenty15 depth-0 section- page-">
+<body class="page page-template page-template-template-builder page-template-template-builder-php opensansy single">
 
 
 	<div id="jacket" class="style-bookmark colors-blue spacing-loose">

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -115,7 +115,7 @@
     </noscript>
 </head>
 
-<body class="home page page-id-2 page-template page-template-template-builder page-template-template-builder-php domain-hub-wsu-edu path-jeremy opensansy single five5 ten8 twenty15 depth-0 section- page-">
+<body class="page page-template page-template-template-builder page-template-template-builder-php opensansy single depth-1">
     <div id="jacket" class="style-bookmark colors-blue spacing-loose">
         <div id="binder" class="fluid folio max-1188">
             <header id="site-header"> </header>

--- a/style-guide/tertiary.html
+++ b/style-guide/tertiary.html
@@ -62,7 +62,7 @@
     <noscript><style>#spine #spine-sitenav ul ul li { display: block !important; }</style></noscript>
 </head>
 
-<body class="home page page-id-2 page-template page-template-template-builder page-template-template-builder-php domain-hub-wsu-edu path-jeremy opensansy single five5 ten8 twenty15 depth-0 section- page-">
+<body class="page page-template page-template-template-builder page-template-template-builder-php opensansy single depth-2">
 
 
 <div id="jacket" class="style-bookmark colors-blue spacing-loose">


### PR DESCRIPTION
* Remove the `home` class from secondary and tertiary pages.
* Remove random (fiveX, tenX, twentyX) classes from all pages.
* Remove domain and path classes from all pages.
* Remove page ID classes from all pages.
* Adjust depth classes to match location in structure.