### PR TITLE
[PR] Adjust jacket and binder classes in the style guide

### DIFF
--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -127,8 +127,8 @@
 <body class="home page page-template page-template-template-builder page-template-template-builder-php opensansy single depth-0">
 
 
-<div id="jacket" class="style-bookmark colors-blue spacing-loose">
-		<div id="binder" class="fluid folio max-1188">
+<div id="jacket" class="style-skeletal colors-default spacing-default">
+		<div id="binder" class="fluid max-1188">
 				<main class="spine-blank-template">
 						<header class="main-header">
 								<div class="header-group hgroup guttered padded-bottom short">

--- a/style-guide/general-elements.html
+++ b/style-guide/general-elements.html
@@ -127,8 +127,8 @@
 <body class="page page-template page-template-template-builder page-template-template-builder-php opensansy single">
 
 
-	<div id="jacket" class="style-bookmark colors-blue spacing-loose">
-		<div id="binder" class="fluid folio max-1188">
+	<div id="jacket" class="style-skeletal colors-default spacing-default">
+		<div id="binder" class="fluid max-1188">
 			<main class="spine-blank-template">
 				<header class="main-header">
 					<div class="header-group hgroup guttered padded-bottom short">

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -116,8 +116,8 @@
 </head>
 
 <body class="page page-template page-template-template-builder page-template-template-builder-php opensansy single depth-1">
-    <div id="jacket" class="style-bookmark colors-blue spacing-loose">
-        <div id="binder" class="fluid folio max-1188">
+    <div id="jacket" class="style-skeletal colors-default spacing-default">
+        <div id="binder" class="fluid max-1188">
             <header id="site-header"> </header>
             <main class="spine-blank-template">
                 <header class="main-header">

--- a/style-guide/tertiary.html
+++ b/style-guide/tertiary.html
@@ -65,8 +65,8 @@
 <body class="page page-template page-template-template-builder page-template-template-builder-php opensansy single depth-2">
 
 
-<div id="jacket" class="style-bookmark colors-blue spacing-loose">
-    <div id="binder" class="fluid folio max-1188">
+<div id="jacket" class="style-skeletal colors-default spacing-default">
+    <div id="binder" class="fluid max-1188">
         <main class="spine-blank-template">
             <header class="main-header">
                 <div class="header-group hgroup guttered padded-bottom short">


### PR DESCRIPTION
* Use `style-skeletal` rather than bookmark.
* Use `color-default` rather than blue.
* Use `spacing-default` rather than loose.
* Remove unused `folio` class from binder.