### PR TITLE
[PR] Move Spine navigation markup to top of HTML document

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,12 @@
+<?php get_template_part( 'parts/after-main' ); ?>
+</div><!--/binder-->
+<?php get_template_part( 'parts/after-binder' ); ?>
+</div><!--/jacket-->
+<?php get_template_part( 'parts/after-jacket' ); ?>
+
+<?php get_template_part( 'parts/contact' ); ?>
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/parts/before-main.php
+++ b/parts/before-main.php
@@ -1,0 +1,3 @@
+<?php
+
+get_template_part( 'spine' );


### PR DESCRIPTION
Overrides the default `footer.php` template and provides a new `parts/before-main.php` so that the primary navigation markup can be output between `#binder` and `main`.