### PR TITLE
[PR] Fetch the source of the full-sized featured image

### DIFF
--- a/parts/headers.php
+++ b/parts/headers.php
@@ -1,7 +1,7 @@
 <?php
 // If a featured image is assigned, apply it as an inline style to the header.
 if ( spine_has_featured_image() ) {
-	$featured_image_src = spine_get_featured_image_src();
+	$featured_image_src = spine_get_featured_image_src( 'full' );
 	$featured_image_position = get_post_meta( get_the_ID(), '_featured_image_position', true );
 
 	if ( ! $featured_image_position || sanitize_html_class( $featured_image_position ) !== $featured_image_position ) {


### PR DESCRIPTION
Per @slocker3 and @allenjohns's request. The parent theme grabs `spine-xlarge_size`by default if no size is set, and we want the highest quality.

@jeremyfelt #reviewmerge?