### PR TITLE
initial style for tablets and phones

### DIFF
--- a/css/01-general-typography.css
+++ b/css/01-general-typography.css
@@ -242,13 +242,28 @@ main ul li:before {
 	right: 0;
 }
 
+@media (max-width: 1250px) {
+
+	.bleed-right .space-case {
+		text-align: center;
+	}
+
+	.bleed-right .space-case:after {
+		margin-left: auto;
+		margin-right: auto;
+		left: 0;
+		right: 0;
+	}
+
+}
+
 /* slight size adjustments for margin-right */
 .margin-right .two {
 	font-size: .9rem;
 }
 
 /* adds crimson and makes the text all caps */
-.bolder {
+.bolder h3 {
 	color: #981e32;
 	text-transform: uppercase;
 }

--- a/css/02-site-header-and-nav.css
+++ b/css/02-site-header-and-nav.css
@@ -16,7 +16,7 @@
 	color: #981e32;
 	font-size: 1em;
 	font-weight: 300;
-	padding: .35em 1.5em .35em .5em;
+	padding: .25em 1.5em .25em .5em;
 	width: 6.5em;
 	transition: all .3s ease;
 }
@@ -48,6 +48,13 @@
 	background-repeat: no-repeat;
 }
 
+.site-search input[placeholder],
+.site-search [placeholder],
+.site-search *[placeholder] {
+	font-family: "Open Sans", "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+	font-weight: 300;
+}
+
 /* --- overwrite an old Spine remnant - will be changed in next release --- */
 #spine nav li.parent.active > a:hover {
 	cursor: pointer;
@@ -77,6 +84,10 @@
 }
 
 @media (max-width: 989px) {
+
+	.site-search {
+		display: none;
+	}
 
 	#binder #spine.darker header {
 		background: #fff;

--- a/css/03-page.css
+++ b/css/03-page.css
@@ -100,16 +100,24 @@ header.main-header {
 	align-items: flex-end;
 }
 
-.has-featured-image header.main-header:after {
-	border: 1px solid rgba(255, 255, 255, .5);
-}
-
 .has-featured-image .main-header .hgroup {
 	display: flex;
 	align-items: flex-end;
 	flex: 1;
 	padding-top: 3.5em;
 	padding-bottom: 3.5em;
+}
+
+/* color treatment over splash images */
+.has-featured-image header.main-header:after,
+.featured-news-item:after {
+	content: "";
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: linear-gradient(155deg, rgba(171, 77, 94, .8) 0%, rgba(171, 77, 94, .4) 10%, rgba(0, 0, 0, 0) 35%);
 }
 
 /* --- breadcrumbs --- */
@@ -536,16 +544,6 @@ div#wsu-video-background:after {
 
 .featured-news-item:hover:before {
 	border-color: #fff;
-}
-
-.featured-news-item:after {
-	content: "";
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	background: linear-gradient(155deg, rgba(171, 77, 94, .8) 0%, rgba(171, 77, 94, .4) 10%, rgba(0, 0, 0, 0) 35%);
 }
 
 .featured-news-item a {

--- a/css/03-page.css
+++ b/css/03-page.css
@@ -160,12 +160,20 @@ header.main-header {
 		padding: 0;
 	}
 
-	/* - no padding on column - */
-	.no-pad .column {
-		padding-left: 0 !important;
-		padding-right: 0 !important;
-	}
+}
 
+.row {
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+}
+
+.row.thirds .column {
+	flex: 1;
+}
+
+#jacket .row > header {
+	flex: 1 100%;
 }
 
 @media (min-width: 989px) {
@@ -228,6 +236,13 @@ header.main-header {
 	margin-left: auto;
 }
 
+/* - no padding on column - */
+.no-pad,
+.no-pad .column {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
 @media (max-width: 1188px) {
 
 	#jacket #binder .bleed-right {
@@ -281,6 +296,16 @@ header.main-header {
 	max-width: 500px;
 }
 
+@media (max-width: 989px) {
+
+	.mid-feature,
+	.img-mid-feature {
+		margin: 2rem 0;
+		padding: 2rem 0;
+	}
+
+}
+
 /* background colors */
 .gray-lightest-back,
 .lightest-back {
@@ -291,7 +316,7 @@ header.main-header {
 .site-footer {
 	background-color: #333;
 	color: rgba(255, 255, 255, .6);
-	margin: 2em 0 0;
+	margin: 0;
 	padding: 6em 0;
 }
 
@@ -315,7 +340,12 @@ header.main-header {
 }
 
 .address-item {
-	padding: 0 .5em;
+	padding: 0 .75em;
+	border-right: 1px solid rgba(255, 255, 255, .2);
+}
+
+.address-item:last-child {
+	border: none;
 }
 
 .address-item:first-child {
@@ -360,6 +390,7 @@ header.main-header {
 		padding-left: 0;
 		padding-right: 0;
 	}
+
 }
 
 /* --- Home page layout --- */
@@ -491,6 +522,22 @@ div#wsu-video-background:after {
 	transition: all .3s ease;
 }
 
+.featured-news-item:before {
+	content: "";
+	border: 1px solid transparent;
+	position: absolute;
+	left: 2em;
+	right: 2em;
+	top: 2em;
+	bottom: 2em;
+	z-index: 2;
+	transition: all .3s ease;
+}
+
+.featured-news-item:hover:before {
+	border-color: #fff;
+}
+
 .featured-news-item:after {
 	content: "";
 	position: absolute;
@@ -502,7 +549,7 @@ div#wsu-video-background:after {
 }
 
 .featured-news-item a {
-	padding: 2em 3em;
+	padding: 4em;
 }
 
 .featured-news-item a:hover {
@@ -578,4 +625,76 @@ div#wsu-video-background:after {
 	max-width: 700px;
 	margin: 0 auto;
 	padding-bottom: 4em;
+}
+
+@media (max-width: 693px) {
+
+	.home-hero,
+	.home-hero #wsu-video-background {
+		height: 500px;
+	}
+
+	.home-hero .hgroup {
+		width: 100%;
+	}
+
+	.home-hero h1.main-header-description {
+		font-size: 1.75em;
+		line-height: 1.25;
+	}
+
+	.home-hero .main-header-name {
+		font-size: .8em;
+		line-height: 1.25;
+		margin-bottom: 1em;
+	}
+
+	.home-hero .hgroup:before {
+		display: none;
+	}
+
+	.row.thirds .column {
+		flex: 1 100%;
+	}
+
+	.area-highlights img {
+		width: 100%;
+	}
+
+	.halves.no-pad .one {
+		margin-bottom: 1em;
+	}
+
+	.featured-news-item a {
+		padding: 3em 2em;
+	}
+
+	.featured-news-item:before {
+		border: none;
+	}
+
+	.news-item-wrap {
+		display: block;
+	}
+
+	.news-item {
+		padding-bottom: 1em;
+	}
+
+	.breadcrumbs,
+	.site-footer .global-links {
+		display: none;
+	}
+
+	.footer-contact-info span {
+		border: none;
+		display: block;
+		width: 100%;
+		padding: 0;
+	}
+
+	.site-footer .email-address {
+		padding-left: 0;
+	}
+
 }

--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -341,7 +341,8 @@
 				</nav>
 				<div class="wsu-signature">
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt=""></a>
-				</div> <address class="footer-contact-info">
+				</div>
+				<address class="footer-contact-info">
 					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
 				</address>
 				<nav class="global-links">
@@ -354,6 +355,7 @@
 					</ul>
 				</nav>
 			</footer>
+
 		</div>
 		<!--/binder-->
 	</div>

--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -49,16 +49,21 @@
 	<div id="jacket" class="style-skeletal colors-default spacing-default">
 		<div id="binder" class="fluid max-1188">
 			<div class="global-bar-wrap">
-				<div class="global-bar"> <a class="global-home" href="https://medicine.wsu.edu">Washington State University</a> </div>
+				<div class="global-bar">
+					<a class="global-home" href="https://medicine.wsu.edu">Washington State University</a>
+				</div>
 			</div>
 			<div id="contact-search" class="site-search">
 				<ul>
 					<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-684"><a href="https://medicine.wsu.edu/contact/">Contact</a></li>
 					<li class="search">
 						<form role="search" method="get" class="search-form" action="https://stage.medicine.wsu.edu/">
-							<label> <span class="screen-reader-text">Search for:</span>
-								<input type="search" class="search-field" placeholder="Search" value="" name="s" /> </label>
-							<input type="submit" class="search-submit" value="Search" /> </form>
+							<label>
+								<span class="screen-reader-text">Search for:</span>
+								<input type="search" class="search-field" placeholder="Search" value="" name="s" />
+							</label>
+							<input type="submit" class="search-submit" value="Search" />
+						</form>
 					</li>
 				</ul>
 			</div>

--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -156,9 +156,12 @@
 								</li>
 							</ul>
 						</nav>
-						<nav id="spine-offsitenav" class="spine-offsitenav"> </nav>
+						<nav id="spine-offsitenav" class="spine-offsitenav">
+						</nav>
+
 					</section>
 					<footer class="spine-footer">
+
 						<nav id="wsu-social-channels" class="spine-social-channels">
 							<ul>
 								<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
@@ -167,6 +170,7 @@
 								<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
 							</ul>
 						</nav>
+
 						<nav id="wsu-global-links" class="spine-global-links">
 							<ul>
 								<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
@@ -175,6 +179,7 @@
 								<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
 							</ul>
 						</nav>
+
 					</footer>
 				</div>
 				<!--/glue-->
@@ -186,7 +191,7 @@
 						<h1 class="main-header-description">Home</h1> </div>
 				</header>
 				<div id="page-2" class="post-2 page type-page status-publish hentry">
-					<section id="builder-section-1477508767365" class="row single home-hero bleed-full">
+					<section class="row single home-hero bleed-full">
 						<div style="" class="column one ">
 							<div id="wsu-video-background"></div>
 							<div class="hgroup">
@@ -195,12 +200,12 @@
 								<h2 class="main-header-description">Training doctors in a wide range of clinical environments to fill health care gaps across the state</h2> </div>
 						</div>
 					</section>
-					<section id="builder-section-1477693573578" class="row single pad-top">
+					<section class="row single pad-top">
 						<div style="" class="column one ">
 							<h2 class="space-case center">Preliminary accreditation received</h2> </div>
 					</section>
 					<div class="section-wrapper bleed-full lightest-back">
-						<section id="builder-section-1477608127248" class="row halves pad-top pad-bottom">
+						<section class="row halves pad-top pad-bottom">
 							<div style="" class="column one bolder">
 								<header>
 									<h3>MD program</h3> </header>
@@ -216,7 +221,7 @@
 						</section>
 					</div>
 					<div class="section-wrapper bleed-full mid-feature center">
-						<section id="builder-section-1477543405895" class="row single ">
+						<section class="row single ">
 							<div style="" class="column one ">
 								<blockquote>
 									<p>“This is a significant moment in Washington State University’s 126-year history. It puts us one step closer to educating physicians who will practice in Washington’s underserved communities and furthers the university’s land-grant mission to
@@ -226,7 +231,7 @@
 							</div>
 						</section>
 					</div>
-					<section id="builder-section-1477614412217" class="row thirds padded-bottom area-highlights">
+					<section class="row thirds padded-bottom area-highlights">
 						<div style="" class="column one ">
 							<p><img src="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-396x161.jpg" alt="esfcom-microscope1" width="396" height="161" class="alignnone size-medium wp-image-441" srcset="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-396x161.jpg 396w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-768x312.jpg 768w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-792x322.jpg 792w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-990x402.jpg 990w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-1188x483.jpg 1188w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1.jpg 1600w"
 												sizes="(max-width: 396px) 100vw, 396px" /></p>
@@ -249,11 +254,11 @@
 							<p><a href="https://stage.medicine.wsu.edu/partners">medicine.wsu.edu/partners</a></p>
 						</div>
 					</section>
-					<section id="builder-section-1477542991494" class="row single pad-top">
+					<section class="row single pad-top">
 						<div style="" class="column one ">
 							<h2 class="space-case center">Transforming medical education in Washington</h2> </div>
 					</section>
-					<section id="builder-section-1477540679778" class="row halves no-pad bleed-full">
+					<section class="row halves no-pad bleed-full">
 						<div style="" class="column one ">
 							<!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
 							<div class="video-wrap-control">
@@ -272,7 +277,7 @@
 						</div>
 					</section>
 					<div class="section-wrapper bleed-right mid-feature home-news">
-						<section id="builder-section-1477589615656" class="row single ">
+						<section class="row single ">
 							<div style="" class="column one ">
 								<h2 class="space-case">In the news</h2>
 								<div class="featured-news-item-wrap">
@@ -291,7 +296,7 @@
 						</section>
 					</div>
 					<div class="section-wrapper lightest-back bleed-full">
-						<section id="builder-section-1477600010681" class="row single pad-top">
+						<section class="row single pad-top">
 							<div style="" class="column one ">
 								<h2 class="space-case center">Distributed clinical campuses</h2>
 								<div class="map-wrap"><img src="https://stage.medicine.wsu.edu/wp-content/themes/wsu-medicine/images/partnership-map.svg"></div>

--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -49,41 +49,36 @@
 	<div id="jacket" class="style-skeletal colors-default spacing-default">
 		<div id="binder" class="fluid max-1188">
 			<div class="global-bar-wrap">
-				<div class="global-bar">
-					<a class="global-home" href="https://medicine.wsu.edu">Washington State University</a>
-				</div>
+				<div class="global-bar"> <a class="global-home" href="https://medicine.wsu.edu">Washington State University</a> </div>
 			</div>
 			<div id="contact-search" class="site-search">
 				<ul>
 					<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-684"><a href="https://medicine.wsu.edu/contact/">Contact</a></li>
 					<li class="search">
 						<form role="search" method="get" class="search-form" action="https://stage.medicine.wsu.edu/">
-							<label>
-								<span class="screen-reader-text">Search for:</span>
-								<input type="search" class="search-field" placeholder="Search" value="" name="s" />
-							</label>
-							<input type="submit" class="search-submit" value="Search" />
-						</form>
+							<label> <span class="screen-reader-text">Search for:</span>
+								<input type="search" class="search-field" placeholder="Search" value="" name="s" /> </label>
+							<input type="submit" class="search-submit" value="Search" /> </form>
 					</li>
 				</ul>
 			</div>
-			<div id="spine" class="spine-column darker search-closed  shelved">
+			<div id="spine" class="spine-column darker search-closed	shelved">
 				<div id="glue" class="spine-glue">
-
-					<header class="spine-header">
-						<a href="https://wsu.edu/" id="wsu-signature">Washington State University</a>
-					</header>
-
+					<header class="spine-header"> <a href="https://wsu.edu/" id="wsu-signature">Washington State University</a> </header>
 					<section id="wsu-actions" class="spine-actions clearfix">
-
 						<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
-							<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
-							<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
-							<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
+							<li id="wsu-search-tab" class="spine-search-tab closed">
+								<button>Search</button>
+							</li>
+							<li id="wsu-contact-tab" class="spine-contact-tab closed">
+								<button>Contact</button>
+							</li>
+							<li id="wsu-share-tab" class="spine-share-tab closed">
+								<button>Share</button>
+							</li>
 						</ul>
-
-					</section><!--/#wsu-actions-->
-
+					</section>
+					<!--/#wsu-actions-->
 					<section id="spine-navigation" class="spine-navigation">
 						<nav id="spine-sitenav" class="spine-sitenav">
 							<ul>
@@ -156,14 +151,9 @@
 								</li>
 							</ul>
 						</nav>
-
-						<nav id="spine-offsitenav" class="spine-offsitenav">
-						</nav>
-
+						<nav id="spine-offsitenav" class="spine-offsitenav"> </nav>
 					</section>
-
 					<footer class="spine-footer">
-
 						<nav id="wsu-social-channels" class="spine-social-channels">
 							<ul>
 								<li class="facebook-channel"><a href="https://www.facebook.com/WSUPullman">facebook</a></li>
@@ -172,7 +162,6 @@
 								<li class="directory-channel"><a href="http://social.wsu.edu">directory</a></li>
 							</ul>
 						</nav>
-
 						<nav id="wsu-global-links" class="spine-global-links">
 							<ul>
 								<li class="mywsu-link"><a href="https://portal.wsu.edu/">myWSU</a></li>
@@ -181,34 +170,129 @@
 								<li class="copyright-link"><a href="https://copyright.wsu.edu">&copy;</a></li>
 							</ul>
 						</nav>
-
 					</footer>
-
-				</div><!--/glue-->
-			</div><!--/spine-->
-
-			<main class="spine-blank-template">
-				<header class="main-header">
-					<div class="header-group hgroup guttered padded-bottom short"> <sup class="sup-header"><span class="sup-header-default">WSU College of Medicine Style Guide</span></sup> <sub class="sub-header"><span class="sub-header-default">Secondary</span></sub> </div>
+				</div>
+				<!--/glue-->
+			</div>
+			<!--/spine-->
+			<main id="wsuwp-main" class="spine-blank-template">
+				<header class="main-header ">
+					<div class="hgroup">
+						<h1 class="main-header-description">Home</h1> </div>
 				</header>
 				<div id="page-2" class="post-2 page type-page status-publish hentry">
-					<section class="row single h1-header gutter pad-top">
-						<div class="column one ">
-							<h1>H1 Header Section</h1> </div>
-					</section>
-					<section class="row single gutter padded-top">
-						<div class="column one">
-							<p>Single Row</p>
+					<section id="builder-section-1477508767365" class="row single home-hero bleed-full">
+						<div style="" class="column one ">
+							<div id="wsu-video-background"></div>
+							<div class="hgroup">
+								<div class="main-header-name">Elson S. Floyd College of Medicine</div>
+								<h1 class="main-header-description rule-thick">Washington&#8217;s community-based medical school</h1>
+								<h2 class="main-header-description">Training doctors in a wide range of clinical environments to fill health care gaps across the state</h2> </div>
 						</div>
 					</section>
-					<section class="row halves">
-						<div class="column one">
-							<p>First half of two halves.</p>
+					<section id="builder-section-1477693573578" class="row single pad-top">
+						<div style="" class="column one ">
+							<h2 class="space-case center">Preliminary accreditation received</h2> </div>
+					</section>
+					<div class="section-wrapper bleed-full lightest-back">
+						<section id="builder-section-1477608127248" class="row halves pad-top pad-bottom">
+							<div style="" class="column one bolder">
+								<header>
+									<h3>MD program</h3> </header>
+								<p>The College seeks students from Washington to join the charter class. Applications accepted through November 27.</p>
+								<p><a href="https://stage.medicine.wsu.edu/md-program/">Explore the MD program</a></p>
+							</div>
+							<div style="" class="column two bolder">
+								<header>
+									<h3>“Bold, audacious, and visionary”</h3> </header>
+								<p>In honor of the late WSU President Elson S. Floyd, the College stands ready to lead a new era in medical education</p>
+								<p><a href="https://stage.medicine.wsu.edu/2016/10/27/preliminary-accreditation-received/">Message from Dean John Tomkowiak</a></p>
+							</div>
+						</section>
+					</div>
+					<div class="section-wrapper bleed-full mid-feature center">
+						<section id="builder-section-1477543405895" class="row single ">
+							<div style="" class="column one ">
+								<blockquote>
+									<p>“This is a significant moment in Washington State University’s 126-year history. It puts us one step closer to educating physicians who will practice in Washington’s underserved communities and furthers the university’s land-grant mission to
+										serve the needs of the state.”
+										<br /> <cite>—Washington State University President Kirk Schulz</cite></p>
+								</blockquote>
+							</div>
+						</section>
+					</div>
+					<section id="builder-section-1477614412217" class="row thirds padded-bottom area-highlights">
+						<div style="" class="column one ">
+							<p><img src="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-396x161.jpg" alt="esfcom-microscope1" width="396" height="161" class="alignnone size-medium wp-image-441" srcset="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-396x161.jpg 396w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-768x312.jpg 768w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-792x322.jpg 792w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-990x402.jpg 990w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1-1188x483.jpg 1188w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-microscope1.jpg 1600w"
+												sizes="(max-width: 396px) 100vw, 396px" /></p>
+							<p><strong>Sustaining health</strong>
+								<br /> Transdisciplinary research tackles complex health care challenges </p>
+							<p><a href="https://stage.medicine.wsu.edu/research">medicine.wsu.edu/research</a></p>
 						</div>
-						<div class="column two">
-							<p>Second half of two halves.</p>
+						<div style="" class="column two ">
+							<p><img src="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes-396x161.jpg" alt="clarkes" width="396" height="161" class="alignnone size-medium wp-image-4827" srcset="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes-396x161.jpg 396w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes-768x312.jpg 768w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes-792x322.jpg 792w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes-990x402.jpg 990w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes-1188x483.jpg 1188w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/clarkes.jpg 1600w"
+												sizes="(max-width: 396px) 100vw, 396px" /></p>
+							<p><strong>Impact across Washington</strong>
+								<br /> Donation helps underwrite the cost of medical school for incoming students </p>
+							<p><a href="#">New Family Endowed Scholarship in Medicine</a></p>
+						</div>
+						<div style="" class="column three ">
+							<p><img src="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2-396x161.jpg" alt="esfcom-bp2" width="396" height="161" class="alignnone size-medium wp-image-286" srcset="https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2-396x161.jpg 396w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2-768x312.jpg 768w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2-792x322.jpg 792w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2-990x402.jpg 990w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2-1188x483.jpg 1188w, https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/esfcom-bp2.jpg 1600w"
+												sizes="(max-width: 396px) 100vw, 396px" /></p>
+							<p><strong>Transforming health care statewide</strong>
+								<br /> Clinical partners enable the Elson S. Floyd College of Medicine to train future physicians in every corner of the state </p>
+							<p><a href="https://stage.medicine.wsu.edu/partners">medicine.wsu.edu/partners</a></p>
 						</div>
 					</section>
+					<section id="builder-section-1477542991494" class="row single pad-top">
+						<div style="" class="column one ">
+							<h2 class="space-case center">Transforming medical education in Washington</h2> </div>
+					</section>
+					<section id="builder-section-1477540679778" class="row halves no-pad bleed-full">
+						<div style="" class="column one ">
+							<!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
+							<div class="video-wrap-control">
+								<div class="video-wrap-inner">
+									<iframe class="inline-youtube-video" id="youtube-video-6t4WAOljj0g" data-video-id="6t4WAOljj0g" data-video-width="560" data-video-height="315" frameborder="0" allowfullscreen="1" title="YouTube video player" width="560" height="315" src="https://www.youtube.com/embed/6t4WAOljj0g?modestbranding=1&amp;showinfo=0&amp;controls=1&amp;rel=0&amp;enablejsapi=1&amp;origin=https%3A%2F%2Fstage.medicine.wsu.edu&amp;widgetid=1"></iframe>
+								</div>
+							</div>
+						</div>
+						<div style="" class="column two ">
+							<!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
+							<div class="video-wrap-control">
+								<div class="video-wrap-inner">
+									<iframe class="inline-youtube-video" id="youtube-video-LUeU74mTQDI" data-video-id="LUeU74mTQDI" data-video-width="560" data-video-height="315" frameborder="0" allowfullscreen="1" title="YouTube video player" width="560" height="315" src="https://www.youtube.com/embed/LUeU74mTQDI?modestbranding=1&amp;showinfo=0&amp;controls=1&amp;rel=0&amp;enablejsapi=1&amp;origin=https%3A%2F%2Fstage.medicine.wsu.edu&amp;widgetid=2"></iframe>
+								</div>
+							</div>
+						</div>
+					</section>
+					<div class="section-wrapper bleed-right mid-feature home-news">
+						<section id="builder-section-1477589615656" class="row single ">
+							<div style="" class="column one ">
+								<h2 class="space-case">In the news</h2>
+								<div class="featured-news-item-wrap">
+									<div class="featured-news-item" style="background-image: url('https://stage.medicine.wsu.edu/wp-content/uploads/sites/1506/2016/10/accreditation-announcement2.jpg')"> <a href="https://news.wsu.edu/2016/10/19/floyd-college-medicine-receives-preliminary-accreditation/"><span class="news-item-head">Floyd College of Medicine receives preliminary accreditation</span><span class="news-item-descr">Achievement keeps medical school on track to admit inaugural class in August</span><br />
+	</a> </div>
+								</div>
+								<div class="news-item-wrap">
+									<div class="news-item"> <a href="https://news.wsu.edu/2016/08/26/10-million-grant-study-disease-native-populations/"><span class="news-item-head">$10 million grant supports study of disease in native populations</span><span class="news-item-descr">The study aims to reduce health risks related to high blood pressure.</span><br />
+		</a> </div>
+									<div class="news-item"> <a href="https://medicine.wsu.edu/2016/10/07/wsu-tri-cities-readies-medical-school/"><span class="news-item-head">WSU Tri-Cities readies itself for medical school</span><span class="news-item-descr">WSU Tri-Cities is growing in many ways as it prepares to become one of the clinical campuses for the Elson S. Floyd College of Medicine.</span><br />
+		</a> </div>
+									<div class="news-item"> <a href="http://www.spokesman.com/stories/2016/apr/04/access-to-free-or-low-cost-medicines-helps-reduce-/"><span class="news-item-head">Access to free or low-cost medicines helps reduce ER and hospital use</span><span class="news-item-descr">Prescription assistance programs have a significant effect on health care utilization.</span><br />
+		</a> </div>
+								</div>
+							</div>
+						</section>
+					</div>
+					<div class="section-wrapper lightest-back bleed-full">
+						<section id="builder-section-1477600010681" class="row single pad-top">
+							<div style="" class="column one ">
+								<h2 class="space-case center">Distributed clinical campuses</h2>
+								<div class="map-wrap"><img src="https://stage.medicine.wsu.edu/wp-content/themes/wsu-medicine/images/partnership-map.svg"></div>
+							</div>
+						</section>
+					</div>
 				</div>
 				<!-- #post -->
 			</main>
@@ -247,9 +331,8 @@
 				</nav>
 				<div class="wsu-signature">
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt=""></a>
-				</div>
-				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span> | <span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span> | <a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a> | <a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+				</div> <address class="footer-contact-info">
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>
@@ -261,7 +344,6 @@
 					</ul>
 				</nav>
 			</footer>
-
 		</div>
 		<!--/binder-->
 	</div>

--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -67,23 +67,23 @@
 					</li>
 				</ul>
 			</div>
-			<div id="spine" class="spine-column darker search-closed	shelved">
+			<div id="spine" class="spine-column darker search-closed shelved">
 				<div id="glue" class="spine-glue">
-					<header class="spine-header"> <a href="https://wsu.edu/" id="wsu-signature">Washington State University</a> </header>
+
+					<header class="spine-header">
+						<a href="https://wsu.edu/" id="wsu-signature">Washington State University</a>
+					</header>
+
 					<section id="wsu-actions" class="spine-actions clearfix">
+
 						<ul id="wsu-actions-tabs" class="spine-actions-tabs spine-tabs clearfix">
-							<li id="wsu-search-tab" class="spine-search-tab closed">
-								<button>Search</button>
-							</li>
-							<li id="wsu-contact-tab" class="spine-contact-tab closed">
-								<button>Contact</button>
-							</li>
-							<li id="wsu-share-tab" class="spine-share-tab closed">
-								<button>Share</button>
-							</li>
+							<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
+							<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
+							<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
 						</ul>
-					</section>
-					<!--/#wsu-actions-->
+
+					</section><!--/#wsu-actions-->
+
 					<section id="spine-navigation" class="spine-navigation">
 						<nav id="spine-sitenav" class="spine-sitenav">
 							<ul>

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -345,8 +345,8 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt=""></a>
 				</div>
 				<address class="footer-contact-info">
-			<span class="dept-name address-item">Elson S. Floyd College of Medicine</span> | <span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span> | <a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a> | <a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
-		  </address>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+				</address>
 				<nav class="global-links">
 					<ul>
 						<li><a href="https://wsu.edu">Washington State University</a></li>

--- a/style-guide/tertiary.html
+++ b/style-guide/tertiary.html
@@ -344,8 +344,8 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt=""></a>
 				</div>
 				<address class="footer-contact-info">
-			<span class="dept-name address-item">Elson S. Floyd College of Medicine</span> | <span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span> | <a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a> | <a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
-		  </address>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+				</address>
 				<nav class="global-links">
 					<ul>
 						<li><a href="https://wsu.edu">Washington State University</a></li>

--- a/style.css
+++ b/style.css
@@ -1008,10 +1008,6 @@ header.main-header {
 	        align-items: flex-end;
 }
 
-.has-featured-image header.main-header:after {
-	border: 1px solid rgba(255, 255, 255, .5);
-}
-
 .has-featured-image .main-header .hgroup {
 	display: -webkit-box;
 	display: -ms-flexbox;
@@ -1024,6 +1020,19 @@ header.main-header {
 	        flex: 1;
 	padding-top: 3.5em;
 	padding-bottom: 3.5em;
+}
+
+/* color treatment over splash images */
+.has-featured-image header.main-header:after,
+.featured-news-item:after {
+	content: "";
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: -webkit-linear-gradient(295deg, rgba(171, 77, 94, .8) 0%, rgba(171, 77, 94, .4) 10%, rgba(0, 0, 0, 0) 35%);
+	background: linear-gradient(155deg, rgba(171, 77, 94, .8) 0%, rgba(171, 77, 94, .4) 10%, rgba(0, 0, 0, 0) 35%);
 }
 
 /* --- breadcrumbs --- */
@@ -1484,17 +1493,6 @@ div#wsu-video-background:after {
 
 .featured-news-item:hover:before {
 	border-color: #fff;
-}
-
-.featured-news-item:after {
-	content: "";
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	background: -webkit-linear-gradient(295deg, rgba(171, 77, 94, .8) 0%, rgba(171, 77, 94, .4) 10%, rgba(0, 0, 0, 0) 35%);
-	background: linear-gradient(155deg, rgba(171, 77, 94, .8) 0%, rgba(171, 77, 94, .4) 10%, rgba(0, 0, 0, 0) 35%);
 }
 
 .featured-news-item a {

--- a/style.css
+++ b/style.css
@@ -257,13 +257,28 @@ main ul li:before {
 	right: 0;
 }
 
+@media (max-width: 1250px) {
+
+	.bleed-right .space-case {
+		text-align: center;
+	}
+
+	.bleed-right .space-case:after {
+		margin-left: auto;
+		margin-right: auto;
+		left: 0;
+		right: 0;
+	}
+
+}
+
 /* slight size adjustments for margin-right */
 .margin-right .two {
 	font-size: .9rem;
 }
 
 /* adds crimson and makes the text all caps */
-.bolder {
+.bolder h3 {
 	color: #981e32;
 	text-transform: uppercase;
 }
@@ -346,7 +361,7 @@ blockquote cite {
 	color: #981e32;
 	font-size: 1em;
 	font-weight: 300;
-	padding: .35em 1.5em .35em .5em;
+	padding: .25em 1.5em .25em .5em;
 	width: 6.5em;
 	-webkit-transition: all .3s ease;
 	transition: all .3s ease;
@@ -379,6 +394,13 @@ blockquote cite {
 	background-repeat: no-repeat;
 }
 
+.site-search input[placeholder],
+.site-search [placeholder],
+.site-search *[placeholder] {
+	font-family: "Open Sans", "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+	font-weight: 300;
+}
+
 /* --- overwrite an old Spine remnant - will be changed in next release --- */
 #spine nav li.parent.active > a:hover {
 	cursor: pointer;
@@ -408,6 +430,10 @@ blockquote cite {
 }
 
 @media (max-width: 989px) {
+
+	.site-search {
+		display: none;
+	}
 
 	#binder #spine.darker header {
 		background: #fff;
@@ -1048,12 +1074,29 @@ header.main-header {
 		padding: 0;
 	}
 
-	/* - no padding on column - */
-	.no-pad .column {
-		padding-left: 0 !important;
-		padding-right: 0 !important;
-	}
+}
 
+.row {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-pack: justify;
+	    -ms-flex-pack: justify;
+	        justify-content: space-between;
+	-ms-flex-wrap: wrap;
+	    flex-wrap: wrap;
+}
+
+.row.thirds .column {
+	-webkit-box-flex: 1;
+	    -ms-flex: 1;
+	        flex: 1;
+}
+
+#jacket .row > header {
+	-webkit-box-flex: 1;
+	    -ms-flex: 1 100%;
+	        flex: 1 100%;
 }
 
 @media (min-width: 989px) {
@@ -1127,6 +1170,13 @@ header.main-header {
 	margin-left: auto;
 }
 
+/* - no padding on column - */
+.no-pad,
+.no-pad .column {
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
 @media (max-width: 1188px) {
 
 	#jacket #binder .bleed-right {
@@ -1180,6 +1230,16 @@ header.main-header {
 	max-width: 500px;
 }
 
+@media (max-width: 989px) {
+
+	.mid-feature,
+	.img-mid-feature {
+		margin: 2rem 0;
+		padding: 2rem 0;
+	}
+
+}
+
 /* background colors */
 .gray-lightest-back,
 .lightest-back {
@@ -1190,7 +1250,7 @@ header.main-header {
 .site-footer {
 	background-color: #333;
 	color: rgba(255, 255, 255, .6);
-	margin: 2em 0 0;
+	margin: 0;
 	padding: 6em 0;
 }
 
@@ -1214,7 +1274,12 @@ header.main-header {
 }
 
 .address-item {
-	padding: 0 .5em;
+	padding: 0 .75em;
+	border-right: 1px solid rgba(255, 255, 255, .2);
+}
+
+.address-item:last-child {
+	border: none;
 }
 
 .address-item:first-child {
@@ -1262,6 +1327,7 @@ header.main-header {
 		padding-left: 0;
 		padding-right: 0;
 	}
+
 }
 
 /* --- Home page layout --- */
@@ -1403,6 +1469,23 @@ div#wsu-video-background:after {
 	transition: all .3s ease;
 }
 
+.featured-news-item:before {
+	content: "";
+	border: 1px solid transparent;
+	position: absolute;
+	left: 2em;
+	right: 2em;
+	top: 2em;
+	bottom: 2em;
+	z-index: 2;
+	-webkit-transition: all .3s ease;
+	transition: all .3s ease;
+}
+
+.featured-news-item:hover:before {
+	border-color: #fff;
+}
+
 .featured-news-item:after {
 	content: "";
 	position: absolute;
@@ -1415,7 +1498,7 @@ div#wsu-video-background:after {
 }
 
 .featured-news-item a {
-	padding: 2em 3em;
+	padding: 4em;
 }
 
 .featured-news-item a:hover {
@@ -1501,6 +1584,80 @@ div#wsu-video-background:after {
 	max-width: 700px;
 	margin: 0 auto;
 	padding-bottom: 4em;
+}
+
+@media (max-width: 693px) {
+
+	.home-hero,
+	.home-hero #wsu-video-background {
+		height: 500px;
+	}
+
+	.home-hero .hgroup {
+		width: 100%;
+	}
+
+	.home-hero h1.main-header-description {
+		font-size: 1.75em;
+		line-height: 1.25;
+	}
+
+	.home-hero .main-header-name {
+		font-size: .8em;
+		line-height: 1.25;
+		margin-bottom: 1em;
+	}
+
+	.home-hero .hgroup:before {
+		display: none;
+	}
+
+	.row.thirds .column {
+		-webkit-box-flex: 1;
+		    -ms-flex: 1 100%;
+		        flex: 1 100%;
+	}
+
+	.area-highlights img {
+		width: 100%;
+	}
+
+	.halves.no-pad .one {
+		margin-bottom: 1em;
+	}
+
+	.featured-news-item a {
+		padding: 3em 2em;
+	}
+
+	.featured-news-item:before {
+		border: none;
+	}
+
+	.news-item-wrap {
+		display: block;
+	}
+
+	.news-item {
+		padding-bottom: 1em;
+	}
+
+	.breadcrumbs,
+	.site-footer .global-links {
+		display: none;
+	}
+
+	.footer-contact-info span {
+		border: none;
+		display: block;
+		width: 100%;
+		padding: 0;
+	}
+
+	.site-footer .email-address {
+		padding-left: 0;
+	}
+
 }
 
 /* ----- Input ----- */


### PR DESCRIPTION
- added homepage content to front.html
- styled placeholder text for site search
- many responsive adjustments, primarily for/on `home-hero`, `site-footer`, and `bleed-` elements. 
- removed pipes from footer address on styleguides