### PR TITLE
correct phone number in footer

### DIFF
--- a/css/00-banner.css
+++ b/css/00-banner.css
@@ -5,5 +5,5 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu
  Template:       spine
- Version:        0.1.7
+ Version:        0.1.8
 */

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@ include_once( __DIR__ . '/includes/class-medicine-bar-graph-shortcode.php' );
 
 add_filter( 'spine_child_theme_version', 'medicine_theme_version' );
 function medicine_theme_version() {
-	return '0.1.7';
+	return '0.1.8';
 }
 
 add_action( 'init', 'medicine_remove_spine_wp_enqueue_scripts' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medicine.wsu.edu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/medicine.wsu.edu"

--- a/parts/after-main.php
+++ b/parts/after-main.php
@@ -19,7 +19,7 @@ $medicine_footer_menu_args = array(
 		<a href="https://wsu.edu"><img src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/wsu-logo-wht.svg" alt="Washington State University logo"></a>
 	</div>
 	<address class="footer-contact-info">
-		<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+		<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 	</address>
 	<nav class="global-links">
 		<ul>

--- a/style-guide/front.html
+++ b/style-guide/front.html
@@ -351,7 +351,7 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt="Washington State University logo"></a>
 				</div>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style-guide/gravity-form.html
+++ b/style-guide/gravity-form.html
@@ -445,7 +445,7 @@
 					</ul>
 				</nav>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style-guide/search-results.html
+++ b/style-guide/search-results.html
@@ -270,7 +270,7 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt="Washington State University logo"></a>
 				</div>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style-guide/secondary-featured-img.html
+++ b/style-guide/secondary-featured-img.html
@@ -345,7 +345,7 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt="Washington State University logo"></a>
 				</div>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -345,7 +345,7 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt="Washington State University logo"></a>
 				</div>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style-guide/tables.html
+++ b/style-guide/tables.html
@@ -372,7 +372,7 @@
 					</ul>
 				</nav>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style-guide/tertiary.html
+++ b/style-guide/tertiary.html
@@ -344,7 +344,7 @@
 					<a href="https://wsu.edu"><img src="../images/wsu-logo-wht.svg" alt="Washington State University logo"></a>
 				</div>
 				<address class="footer-contact-info">
-					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093387944">509-338-7944</a>
+					<span class="dept-name address-item">Elson S. Floyd College of Medicine</span><span class="street-address address-item">Washington State University, PO Box 1495, Spokane, WA 99210-1495</span><a class="email-address address-item" href="mailto:medicine@wsu.edu">medicine@wsu.edu</a><a class="telephone-number address-item" href="tel:5093587944">509-358-7944</a>
 				</address>
 				<nav class="global-links">
 					<ul>

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu
  Template:       spine
- Version:        0.1.7
+ Version:        0.1.8
 */
 
 /* --- general typography and type classes --- */


### PR DESCRIPTION
The telephone number in the footer needs to be corrected -- should be 509-358-7944 instead of 509-338-7944.